### PR TITLE
Only deploy the web version on pushes to master

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: barichello/godot-ci:3.4
+    if: github.ref == 'refs/heads/mistress'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Stop decker from sniping my tests