### PR TITLE
Reduce the number of raycasts for occluding vision cones. Also added …

### DIFF
--- a/src/entities/Camera.gd
+++ b/src/entities/Camera.gd
@@ -6,6 +6,8 @@ export var scan_speed = 0.15
 
 var scan_direction = 1
 
+var has_cone = true
+
 func _process(_delta):
 	
 	var new_angle = rotation_degrees + (scan_speed * scan_direction)

--- a/src/entities/Sentry.gd
+++ b/src/entities/Sentry.gd
@@ -11,6 +11,8 @@ enum DIR {
 
 var direction = DIR.FORWARDS
 
+var has_cone = true
+
 func _ready():
 	# We do the looping logic ourselves so we can wait inbetween ends
 	path_follow.set_loop(false)

--- a/src/entities/Sentry.tscn
+++ b/src/entities/Sentry.tscn
@@ -44,7 +44,7 @@ tracks/0/keys = {
 extents = Vector2( 14.2702, 14.7221 )
 
 [node name="Sentry" type="KinematicBody2D"]
-collision_layer = 17
+collision_layer = 25
 script = ExtResource( 2 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/src/entities/SentryWithPath.tscn
+++ b/src/entities/SentryWithPath.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
-[ext_resource path="res://src/entities/Sentry.gd" type="Script" id=1]
 [ext_resource path="res://src/entities/Sentry.tscn" type="PackedScene" id=2]
 
 [sub_resource type="Curve2D" id=1]
@@ -17,7 +16,5 @@ position = Vector2( -0.311279, 1.88684 )
 rotate = false
 loop = false
 
-[node name="Sentry" type="KinematicBody2D" parent="PathFollow2D" instance=ExtResource( 2 )]
-collision_layer = 17
-script = ExtResource( 1 )
+[node name="Sentry" parent="PathFollow2D" instance=ExtResource( 2 )]
 drive_speed = 50

--- a/src/levels/SecondLevel.tscn
+++ b/src/levels/SecondLevel.tscn
@@ -8,7 +8,7 @@
 [ext_resource path="res://src/entities/Camera.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/entities/SentryWithPath.tscn" type="PackedScene" id=7]
 
-[node name="Sec ondLevel" type="Node2D"]
+[node name="SecondLevel" type="Node2D"]
 script = ExtResource( 3 )
 
 [node name="background" type="TileMap" parent="."]
@@ -54,6 +54,9 @@ tile_data = PoolIntArray( 524320, 21, 0, 524321, 23, 0, 589853, 9, 0, 589854, 9,
 
 [node name="Player" parent="." instance=ExtResource( 2 )]
 position = Vector2( 113.839, 449.246 )
+
+[node name="Upgrades" parent="Player" index="7"]
+has_zapper = true
 
 [editable path="foreground/Camera2"]
 [editable path="foreground/Path2D"]


### PR DESCRIPTION
…vision cone collision to sentries, and excluded a vision cone's relevant parent from occluding, so they don't occlude themselves.